### PR TITLE
Replace Timestring dependency with a newer Fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tornado>=4.0.0
 valideer>=0.3.1
-timestring>=1.6.1
+timestring-pleasantone==1.8.1
 tornpsql


### PR DESCRIPTION
This commit replaces Timestring with a newer version that is more actively maintained than Steve Peak's original repository. The alternative to this approach would be to bring in a fork of timestring and update it ourselves. For as minimally as this depedency needs to be updated, though, I'm not entirely certain if this is necessary.